### PR TITLE
feat: auto-progress platform match

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -202,6 +202,7 @@ export default function Page() {
 
   function choose(val) {
     setAnswers((prev) => ({ ...prev, [currentQ.key]: val }));
+    setTimeout(next, 300);
   }
 
   function next() {
@@ -878,7 +879,7 @@ export default function Page() {
                       </div>
                       {leadError && <div className="text-sm text-rose-400">{leadError}</div>}
                       <div className="text-xs text-white/50">
-                        Mit „Weiter“ stimmst du zu, dass wir dich zu deinem Ergebnis kontaktieren dürfen.
+                        Mit „Ergebnis anzeigen“ stimmst du zu, dass wir dich zu deinem Ergebnis kontaktieren dürfen.
                       </div>
                     </form>
                   )}
@@ -981,14 +982,6 @@ export default function Page() {
                       >
                         Zurück
                       </button>
-                      <button
-                        onClick={next}
-                        disabled={answers[currentQ.key] == null}
-                        className="ml-auto px-4 py-2 rounded text-white disabled:opacity-40"
-                        style={{ background: ACCENT }}
-                      >
-                        {step < QUESTIONS.length ? "Weiter" : "Ergebnis anzeigen"}
-                      </button>
                     </div>
                   )}
 
@@ -1005,7 +998,7 @@ export default function Page() {
                         className="ml-auto px-4 py-2 rounded text-white w-1/2 md:w-auto"
                         style={{ background: ACCENT }}
                       >
-                        Weiter
+                        Ergebnis anzeigen
                       </button>
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- automatically advance to the next question in the platform match once an answer is chosen
- remove manual "Weiter" button from the question stage
- keep an "Ergebnis anzeigen" button on the final step

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a45f324650832eb06d68407714716e